### PR TITLE
Fixed missing renewed posting url + Added from email address configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ Create a yaml config file with the following content:
 email: <craigslist login>
 password: <craigslist password>
 notify: <comma separated list of emails>
-from: <from email address>
 #
 # Optional parameters
 #
+# specify sender email address
+from: <sender email address>
 # set to 1 to suppress notification emails on renewal
 no_success_mail: <1|0>
 # set to 1 to renew all posts available for renewal

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Create a yaml config file with the following content:
 email: <craigslist login>
 password: <craigslist password>
 notify: <comma separated list of emails>
+from: <from email address>
 #
 # Optional parameters
 #

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Only perl is necessary plus the following non-default modules, which you can dow
 
 * `WWW::Mechanize`
 * `MIME::Lite`
-* `HTML::TreeBuilder`
 * `HTML::TableExtract`
 * `YAML`
 * `List::MoreUtils`

--- a/craigslist-renew.pl
+++ b/craigslist-renew.pl
@@ -25,7 +25,6 @@ defined($ARGV[0]) || die("Usage: $0 [--expired] <config.yml>\n");
 
 my $config = LoadFile($ARGV[0]);
 my $NOTIFY = $config->{notify};
-my $FROM = $config->{from};
 my $SUBJECT = "Craigslist Automatic Renewal";
 my $url = "https://accounts.craigslist.org/login";
 
@@ -128,11 +127,13 @@ sub notify {
     }
     elsif (!$config->{'no_success_mail'} || $check_expired) {
         my $msg = MIME::Lite->new(
-                    From    => $FROM,
                     To      => $NOTIFY,
                     Subject => $SUBJECT,
                     Data    => $message,
                     );
+        if ($config->{from}) {
+            $msg->add(From => $config->{from});
+        }
         $msg->send;
     }
 }

--- a/craigslist-renew.pl
+++ b/craigslist-renew.pl
@@ -77,23 +77,16 @@ while (1) {
     }
 
     foreach my $form_id (@forms) {
-        # click the renew button
         my $form = $mech->form_number($form_id);
+
+        # fetch posting link
+        my $postid = (split('/', $form->action()))[-1];
+        my $link = $mech->find_link(url_regex => qr/$postid\.html/);
+
+        # click the renew button
         $mech->submit_form();
         if ($mech->content() =~  /This posting has been renewed/) {
-            # fetch the title and link of the confirmation page
-            my $title=""; my $link="";
-            my $root = HTML::TreeBuilder->new_from_content($mech->content());
-            my @t = $root->look_down('_tag' => 'span', 'class' => 'postingtitletext');
-            my @l = $root->look_down('_tag' => 'div', 'class' => 'managestatus')->look_down('_tag' => 'a', 'target' => '_blank');
-            if (@t) {
-                $title = $t[0]->as_trimmed_text();
-            }
-            if (@l) {
-                $link = $l[0]->attr('href');
-            }
-
-            notify("Renewed \"$title\" (" . $link . ")");
+            notify("Renewed \"" . $link->text() . "\" (" . $link->url() . ")");
             $renewed++;
         }
         else {

--- a/craigslist-renew.pl
+++ b/craigslist-renew.pl
@@ -163,7 +163,7 @@ sub check_expired {
             foreach my $posting (@$required) {
                 my $title = $posting->{'title'};
                 my $area = $posting->{'area'} // "";
-                if ($info{'title'} =~ /$title/i and $info{'area'} =~ /$area/i) {
+                if ($info{'title'} =~ /\Q$title/i and $info{'area'} =~ /$area/i) {
                     $posting->{'active'} = 1;
                 }
             }

--- a/craigslist-renew.pl
+++ b/craigslist-renew.pl
@@ -27,6 +27,7 @@ defined($ARGV[0]) || die("Usage: $0 [--expired] <config.yml>\n");
 
 my $config = LoadFile($ARGV[0]);
 my $NOTIFY = $config->{notify};
+my $FROM = $config->{from};
 my $SUBJECT = "Craigslist Automatic Renewal";
 my $url = "https://accounts.craigslist.org/login";
 
@@ -136,6 +137,7 @@ sub notify {
     }
     elsif (!$config->{'no_success_mail'} || $check_expired) {
         my $msg = MIME::Lite->new(
+                    From    => $FROM,
                     To      => $NOTIFY,
                     Subject => $SUBJECT,
                     Data    => $message,

--- a/craigslist-renew.pl
+++ b/craigslist-renew.pl
@@ -9,9 +9,7 @@
 use strict;
 use warnings;
 use WWW::Mechanize;
-use Data::Dumper;
 use MIME::Lite;
-use HTML::TreeBuilder;
 use HTML::TableExtract;
 use Getopt::Long;
 use YAML qw( LoadFile );


### PR DESCRIPTION
I have changed the way of fetching the renewed posting title and url since the previous code no longer works in extracting the url anymore as this information is actually available prior to clicking the renew button.

I have also included a new required parameter to configure the from email address going out in notification.

Feel free to merge these changes.